### PR TITLE
example-runtime-bundle to 7.0.12

### DIFF
--- a/env/requirements.yaml
+++ b/env/requirements.yaml
@@ -9,7 +9,7 @@ dependencies:
   version: 2.3.58
 - name: example-runtime-bundle
   repository: http://jenkins-x-chartmuseum:8080
-  version: 7.0.11
+  version: 7.0.12
 - name: rabbitmq
   repository: https://kubernetes-charts.storage.googleapis.com
   version: 0.8.0


### PR DESCRIPTION
Promote example-runtime-bundle to version 7.0.12