### PR TITLE
ttc-connectors-dummytwitter to 1.0.16

### DIFF
--- a/env/requirements.yaml
+++ b/env/requirements.yaml
@@ -10,3 +10,6 @@ dependencies:
 - name: rabbitmq
   repository: https://kubernetes-charts.storage.googleapis.com
   version: 0.8.0
+- name: ttc-connectors-dummytwitter
+  repository: http://jenkins-x-chartmuseum:8080
+  version: 1.0.16


### PR DESCRIPTION
Promote ttc-connectors-dummytwitter to version 1.0.16