### PR TITLE
ttc-dashboard-ui to 0.0.31

### DIFF
--- a/env/requirements.yaml
+++ b/env/requirements.yaml
@@ -10,3 +10,6 @@ dependencies:
 - name: rabbitmq
   repository: https://kubernetes-charts.storage.googleapis.com
   version: 0.8.0
+- name: ttc-dashboard-ui
+  repository: http://jenkins-x-chartmuseum:8080
+  version: 0.0.31


### PR DESCRIPTION
Promote ttc-dashboard-ui to version 0.0.31