### PR TITLE
ttc-connectors-dummytwitter to 1.0.17

### DIFF
--- a/env/requirements.yaml
+++ b/env/requirements.yaml
@@ -16,3 +16,6 @@ dependencies:
 - name: ttc-connectors-ranking
   repository: http://jenkins-x-chartmuseum:8080
   version: 1.0.11
+- name: ttc-connectors-dummytwitter
+  repository: http://jenkins-x-chartmuseum:8080
+  version: 1.0.17


### PR DESCRIPTION
Promote ttc-connectors-dummytwitter to version 1.0.17