### PR TITLE
ttc-connectors-processing to 1.0.11

### DIFF
--- a/env/requirements.yaml
+++ b/env/requirements.yaml
@@ -19,3 +19,6 @@ dependencies:
 - name: ttc-connectors-dummytwitter
   repository: http://jenkins-x-chartmuseum:8080
   version: 1.0.17
+- name: ttc-connectors-processing
+  repository: http://jenkins-x-chartmuseum:8080
+  version: 1.0.11


### PR DESCRIPTION
Promote ttc-connectors-processing to version 1.0.11