### PR TITLE
ttc-infra-gateway to 1.0.8

### DIFF
--- a/env/requirements.yaml
+++ b/env/requirements.yaml
@@ -22,3 +22,6 @@ dependencies:
 - name: ttc-connectors-processing
   repository: http://jenkins-x-chartmuseum:8080
   version: 1.0.12
+- name: ttc-infra-gateway
+  repository: http://jenkins-x-chartmuseum:8080
+  version: 1.0.8


### PR DESCRIPTION
Promote ttc-infra-gateway to version 1.0.8