### PR TITLE
ttc-infra-gateway to 1.0.9

### DIFF
--- a/env/requirements.yaml
+++ b/env/requirements.yaml
@@ -24,7 +24,7 @@ dependencies:
   version: 1.0.13
 - name: ttc-infra-gateway
   repository: http://jenkins-x-chartmuseum:8080
-  version: 1.0.8
+  version: 1.0.9
 - name: ttc-connectors-reward
   repository: http://jenkins-x-chartmuseum:8080
   version: 1.0.11


### PR DESCRIPTION
Promote ttc-infra-gateway to version 1.0.9