### PR TITLE
example-runtime-bundle to 7.0.19

### DIFF
--- a/env/requirements.yaml
+++ b/env/requirements.yaml
@@ -12,7 +12,7 @@ dependencies:
   version: 0.8.0
 - name: example-runtime-bundle
   repository: http://jenkins-x-chartmuseum:8080
-  version: 7.0.18
+  version: 7.0.19
 - alias: activitipostgresql
   name: postgresql
   repository: https://kubernetes-charts.storage.googleapis.com


### PR DESCRIPTION
Promote example-runtime-bundle to version 7.0.19