### PR TITLE
example-runtime-bundle to 7.0.21

### DIFF
--- a/env/requirements.yaml
+++ b/env/requirements.yaml
@@ -9,7 +9,7 @@ dependencies:
   version: 2.3.58
 - name: example-runtime-bundle
   repository: http://jenkins-x-chartmuseum:8080
-  version: 7.0.20
+  version: 7.0.21
 - alias: activitipostgresql
   name: postgresql
   repository: https://kubernetes-charts.storage.googleapis.com


### PR DESCRIPTION
Promote example-runtime-bundle to version 7.0.21