### PR TITLE
example-runtime-bundle to 7.0.28

### DIFF
--- a/env/requirements.yaml
+++ b/env/requirements.yaml
@@ -9,7 +9,7 @@ dependencies:
   version: 2.3.58
 - name: example-runtime-bundle
   repository: http://jenkins-x-chartmuseum:8080
-  version: 7.0.27
+  version: 7.0.28
 - name: infrastructure
   repository: file://../infrastructure
   version: 0.1.0


### PR DESCRIPTION
Promote example-runtime-bundle to version 7.0.28