### PR TITLE
example-runtime-bundle to 7.0.74

### DIFF
--- a/env/requirements.yaml
+++ b/env/requirements.yaml
@@ -9,7 +9,7 @@ dependencies:
   version: 2.3.58
 - name: example-runtime-bundle
   repository: http://jenkins-x-chartmuseum:8080
-  version: 7.0.73
+  version: 7.0.74
 - name: infrastructure
   repository: https://activiti.github.io/activiti-cloud-charts/
   version: 0.1.6


### PR DESCRIPTION
Promote example-runtime-bundle to version 7.0.74