### PR TITLE
ttc-connectors-processing to 1.0.29

### DIFF
--- a/env/requirements.yaml
+++ b/env/requirements.yaml
@@ -16,6 +16,9 @@ dependencies:
 - name: ttc-connectors-dummytwitter
   repository: http://jenkins-x-chartmuseum:8080
   version: 1.0.57
+- name: ttc-connectors-processing
+  repository: http://jenkins-x-chartmuseum:8080
+  version: 1.0.29
 - name: ttc-connectors-ranking
   repository: http://jenkins-x-chartmuseum:8080
   version: 1.0.32


### PR DESCRIPTION
Promote ttc-connectors-processing to version 1.0.29